### PR TITLE
Add missing initialisation of Security slice

### DIFF
--- a/model/high/v3/operation.go
+++ b/model/high/v3/operation.go
@@ -81,6 +81,7 @@ func (o *Operation) Walk(ctx context.Context, operation *v3.Operation) {
 	}
 
 	if operation.Security != nil {
+		o.Security = []*drBase.SecurityRequirement{}
 		for i, security := range operation.Security {
 			security := security
 			s := &drBase.SecurityRequirement{}


### PR DESCRIPTION
The missing initialisation of this slice makes the case where a `security: []` is present indistinguishable from when no `security` property is present, so it's not possible to detect when security has been removed from a single operation by overriding a global security policy.

See https://github.com/daveshanley/vacuum/issues/431 for more info.