### PR TITLE
fix duplicate description on catalog content pages

### DIFF
--- a/printingpress/aggregate_test.go
+++ b/printingpress/aggregate_test.go
@@ -245,6 +245,12 @@ Hidden direct page.
 
 	aboutHTML := readAggregateFile(t, filepath.Join(outputDir, "about.html"))
 	assert.Contains(t, aboutHTML, `<sl-breadcrumb-item href="guides.html">GUIDES</sl-breadcrumb-item>`)
+	breadcrumbIndex := strings.Index(aboutHTML, `<sl-breadcrumb class="pp-breadcrumb">`)
+	descriptionIndex := strings.Index(aboutHTML, "Higher-level catalog context.")
+	require.NotEqual(t, -1, breadcrumbIndex)
+	require.NotEqual(t, -1, descriptionIndex)
+	assert.Less(t, breadcrumbIndex, descriptionIndex)
+	assert.Equal(t, 1, strings.Count(aboutHTML, "Higher-level catalog context."))
 	assert.Contains(t, aboutHTML, "Shared catalog note.")
 	assert.Contains(t, aboutHTML, `src="assets/docs/about/map.svg"`)
 	assert.Contains(t, aboutHTML, `href="guides/setup.html"`)

--- a/printingpress/aggregate_writer.go
+++ b/printingpress/aggregate_writer.go
@@ -494,7 +494,7 @@ func (ap *AggregatePrintingPress) writeCatalogHTML(catalog *ppmodel.CatalogSite)
 		}
 		contentPath := filepath.Join(ap.config.OutputDir, filepath.FromSlash(contentPage.Href))
 		content := render.ContentPageTemplWithBreadcrumb(contentPage, "", catalogContentPageBreadcrumb(contentPage))
-		page := ap.catalogPageData(contentPage.Href, fmt.Sprintf("%s - %s", contentPage.Title, catalog.Title), contentPage.Description, nil, false, content)
+		page := ap.catalogPageData(contentPage.Href, fmt.Sprintf("%s - %s", contentPage.Title, catalog.Title), "", nil, false, content)
 		page = withCatalogContentNav(page, catalog, "content/"+contentPage.Slug)
 		if err := writeCatalogPage(contentPath, page); err != nil {
 			return nil, err


### PR DESCRIPTION
Catalog content pages rendered the page description twice: once from the page chrome and again from the content template. Pass an empty description to catalogPageData so only the content-rendered copy appears, and add test assertions that the description occurs once and follows the breadcrumb.